### PR TITLE
deps: Re-add Ruby 2.7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby: ['3.0', '3.1', '3.2']
+        ruby: ['2.7', '3.0', '3.1', '3.2']
         gemfile:
           - gemfiles/jekyll_3.9.gemfile
           - gemfiles/jekyll_4.0.gemfile

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2021-2022 toshimaru
+Copyright (c) 2021-2023 toshimaru
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/jekyll-theme-classless-simple.gemspec
+++ b/jekyll-theme-classless-simple.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
     f.match(/^(assets|_layouts|_includes|_sass|LICENSE|README|_config\.yml)/i)
   end
 
-  spec.required_ruby_version = '>= 3.0.0'
+  spec.required_ruby_version = '>= 2.7.0'
 
   spec.add_runtime_dependency 'jekyll', '>= 3.9'
   spec.add_runtime_dependency 'jekyll-feed'

--- a/view-on-github.md
+++ b/view-on-github.md
@@ -1,7 +1,5 @@
 ---
-layout: page
+layout: base
 title: View on GitHub
 redirect_to: https://github.com/toshimaru/jekyll-theme-classless-simple
 ---
-
-# View on GitHub


### PR DESCRIPTION
Although Ruby 2.7 is an EOL version, some systems still use it.

Related: #18